### PR TITLE
FCMのHTTP v1への移行対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'lowdown', require: false
 
 # FCM
 gem 'andpush', require: false
-gem 'fcm', require: false
+gem 'fcm', '~> 2.0.0', require: false
 
 # Debugging
 gem 'pry'

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you are starting from scratch, it is recommended using [anpotic](https://gith
 
 ```ruby
 gem 'apnotic' # APNs
-gem 'andpush' # FCM
+gem 'fcm' # FCM *andpush is not maintenance
 ```
 
 ### Walkthrough to Writing a Notifier
@@ -220,10 +220,12 @@ end
 ```ruby
 Pushing.configure do |config|
   # Adapter that is used to send push notifications through FCM
-  config.fcm.adapter = Rails.env.test? ? :test : :andpush
+  config.fcm.adapter = Rails.env.test? ? :test : :fcm_gem
 
-  # Your FCM servery key that can be found here: https://console.firebase.google.com/project/_/settings/cloudmessaging
-  config.fcm.server_key = 'YOUR_FCM_SERVER_KEY'
+  # Google application credentials that are used to send push notifications through FCM
+  # https://github.com/decision-labs/fcm?tab=readme-ov-file#getting-started
+  config.fcm.google_application_credentials = 'YOUR_GOOGLE_APPLICATION_CREDENTIALS_PATH'
+  config.fcm.firebase_project_id = 'YOUR_FIREBASE_PROJECT_ID'
 
   # Adapter that is used to send push notifications through APNs
   config.apn.adapter = Rails.env.test? ? :test : :apnotic
@@ -284,7 +286,7 @@ Pushing provides first-class support for testing. In order to test your notifier
 # config/initializers/pushing.rb
 Pushing.configure do |config|
   config.apn.adapter = Rails.env.test? ? :test : :apnotic
-  config.fcm.adapter = Rails.env.test? ? :test : :andpush
+  config.fcm.adapter = Rails.env.test? ? :test : :fcm_gem
 end
 ```
 

--- a/lib/generators/pushing/templates/initializer.rb
+++ b/lib/generators/pushing/templates/initializer.rb
@@ -1,9 +1,11 @@
 Pushing.configure do |config|
   # Adapter that is used to send push notifications through FCM
-  config.fcm.adapter = Rails.env.test? ? :test : :andpush
+  config.fcm.adapter = Rails.env.test? ? :test : :fcm_gem
 
-  # Your FCM servery key that can be found here: https://console.firebase.google.com/project/_/settings/cloudmessaging
-  config.fcm.server_key = 'YOUR_FCM_SERVER_KEY'
+  # Google application credentials that are used to send push notifications through FCM
+  # https://github.com/decision-labs/fcm?tab=readme-ov-file#getting-started
+  config.fcm.google_application_credentials = 'YOUR_GOOGLE_APPLICATION_CREDENTIALS_PATH'
+  config.fcm.firebase_project_id = 'YOUR_FIREBASE_PROJECT_ID'
 
   # Adapter that is used to send push notifications through APNs
   config.apn.adapter = Rails.env.test? ? :test : :apnotic

--- a/lib/generators/pushing/templates/template.json+fcm.jbuilder
+++ b/lib/generators/pushing/templates/template.json+fcm.jbuilder
@@ -1,75 +1,56 @@
-# In this file you can customize the FCM payload. For more details about Firebase Cloud Messaging HTTP Protocol, see
-# Google's offitial documentation here: https://goo.gl/tgssxy
+# Usage: rails g pushing:template json+fcm
+#
+# This will create a template.json+fcm.jbuilder file in your app's lib/generators/pushing/templates directory.
+# You can customize this file to change the payload that will be sent to the FCM server.
+# The payload will be built using the json object that is passed to the jbuilder template.
+#
+=begin
+Minimum payload sample:
+{
+  "message":{
+    "token":"bk3RNwTe3H0:CI2k_HHwgIpoDKCIZvvDMExUdFQ3P1...",
+    "notification":{
+      "body":"This is an FCM notification message!",
+      "title":"FCM Message"
+    }
+  }
+}
+=end
 
-# The recipient of a message. The value can be a device's registration token, a device group's notification key, or a
-# single topic (prefixed with /topics/). Either the 'to' or 'registration_ids' key should be present.
-json.to 'REPLACE_WITH_ACTUAL_REGISTRATION_ID_OR_TOPIC'
+# See https://firebase.google.com/docs/cloud-messaging/send-message or https://github.com/decision-labs/fcm/blob/master/lib/fcm.rb#L20-L48
+json.name 'string'
 
-# The recipient of a multicast message, a message sent to more than one registration token. Either the 'to' or
-# 'registration_ids' key should be present.
-# json.registration_ids 'REPLACE_WITH_ACTUAL_REGISTRATION_IDS_OR_TOPIC'
-
-# A logical expression of conditions that determine the message target.
-# json.condition 'Topic'
-
-# This parameter identifies a group of messages (e.g., with collapse_key:
-# "Updates Available") that can be collapsed.
-# json.collapse_key "Updates Available"
-
-# Sets the priority of the message. Valid values are "normal" and "high".
-# json.priority "high"
-
-# How long (in seconds) the message should be kept in FCM storage if the device is offline.
-# json.time_to_live 4.weeks.to_i
-
-# The package name of the application where the registration tokens must match in order to receive the message.
-# json.restricted_package_name 'com.yourdomain.app'
-
-# This parameter, when set to true, allows developers to test a request without actually sending a message.
-# json.dry_run true
-
-# The custom key-value pairs of the message's payload.
-# json.data do
-#   json.custom_data "data..."
-# end
-
-# The predefined, user-visible key-value pairs of the notification payload. 
-json.notification do
-  # The notification's title.
-  json.title 'REPLACE_WITH_ACTUAL_TITLE'
-
-  # The notification's body text.
-  json.body 'REPLACE_WITH_ACTUAL_BODY'
-
-  # The notification's channel id (new in Android O).
-  # json.android_channel_id "my_channel_01"
-
-  # The notification's icon.
-  json.icon 1
-
-  # The sound to play when the device receives the notificatio
-  json.sound 'default'
-
-  # Identifier used to replace existing notifications in the notification drawer.
-  # json.tag 'tag-name'
-
-  # The notification's icon color, expressed in #rrggbb format.
-  # json.color "#ffffff"
-
-  # The action associated with a user click on the notification.
-  # json.click_action "OPEN_ACTIVITY_1"
-
-  # The key to the body in the app's string resources to use to localize the body to the user's current localization.
-  # json.body_loc_key 'key in Localizable.strings'
-
-  # String values to be used in place of the format specifiers in 'body_loc_key' to use to localize the body to the
-  # user's current localization.
-  # json.body_loc_args ['arg1', 'arg2']
-
-  # The key to the title in the app's string resources to use to localize the title to the user's current localization.
-  # json.title_loc_key 'key in Localizable.strings'
-
-  # String values to be used in place of the format specifiers in title_loc_key to use to localize the title text to
-  # the user's current localization.
-  # json.title_loc_args ['arg1', 'arg2']
+json.data do
+  json.something_key 'string'
 end
+
+# https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages?hl=ja#Notification
+json.notification do
+  ...
+end
+
+# https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages?hl=ja#androidconfig
+json.android do
+  ...
+end
+
+# https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages?hl=ja#webpushconfig
+json.webpush do
+  ...
+end
+
+# https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages?hl=ja#ApnsConfig
+json.apns do
+  ...
+end
+
+# https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages?hl=ja#FcmOptions
+json.fcm_options do
+  ...
+end
+
+# Union field target can be only one of the following:
+json.token 'string'
+json.topic 'string'
+json.condition 'string'
+# End of list of possible types for union field target

--- a/test/fixtures/base_notifier/welcome.json+fcm.jbuilder
+++ b/test/fixtures/base_notifier/welcome.json+fcm.jbuilder
@@ -1,4 +1,4 @@
 json.data do
   json.message 'Hello FCM!'
 end
-json.to 'device-token'
+json.token 'device-token'

--- a/test/integration/adapters/fcm_adapter_test.rb
+++ b/test/integration/adapters/fcm_adapter_test.rb
@@ -13,5 +13,8 @@ class FcmAdapterIntegrationTest < ActiveSupport::TestCase
   def adapter
     'fcm'
   end
-end
 
+  def stub_url
+    "https://fcm.googleapis.com/v1/projects/#{Pushing.config.fcm.firebase_project_id}/messages:send"
+  end
+end

--- a/test/integration/fcm_test_cases.rb
+++ b/test/integration/fcm_test_cases.rb
@@ -22,8 +22,9 @@ module FcmTestCases
   def test_observer_can_observe_responses_from_fcm
     MaintainerNotifier.register_observer FcmTokenHandler.new
 
-    stub_request(:post, "https://fcm.googleapis.com/fcm/send").to_return(
+    stub_request(:post, stub_url).to_return(
       status: 200,
+      headers: {},
       body: {
         multicast_id: 216,
         success: 3,
@@ -49,7 +50,7 @@ module FcmTestCases
   end
 
   def test_notifier_raises_exception_on_http_client_error
-    stub_request(:post, "https://fcm.googleapis.com/fcm/send").to_return(status: 400)
+    stub_request(:post, stub_url).to_return(status: 400)
 
     error = assert_raises Pushing::FcmDeliveryError do
       MaintainerNotifier.build_result(adapter, fcm: true).deliver_now!
@@ -60,7 +61,7 @@ module FcmTestCases
   end
 
   def test_notifier_can_rescue_error_on_error_response
-    stub_request(:post, "https://fcm.googleapis.com/fcm/send").to_return(status: 400)
+    stub_request(:post, stub_url).to_return(status: 400)
 
     assert_nothing_raised do
       NotifierWithRescueHandler.fcm.deliver_now!
@@ -73,4 +74,9 @@ module FcmTestCases
   def adapter
     raise NotImplementedError
   end
+
+  def stub_url
+    raise NotImplementedError
+  end
+
 end

--- a/test/integration/test_helper.rb
+++ b/test/integration/test_helper.rb
@@ -8,7 +8,9 @@ WebMock.allow_net_connect!
 
 Pushing::Base.logger = Logger.new(STDOUT)
 Pushing.configure do |config|
-  config.fcm.server_key = ENV.fetch('FCM_TEST_SERVER_KEY')
+  config.fcm.google_application_credentials = ENV.fetch('FCM_TEST_GOOGLE_APPLICATION_CREDENTIALS')
+  config.fcm.firebase_project_id            = ENV.fetch('FCM_TEST_FIREBASE_PROJECT_ID')
+
 
   config.apn.environment          = :development
   config.apn.certificate_path     = File.join(File.expand_path("./"), ENV.fetch('APN_TEST_CERTIFICATE_PATH'))


### PR DESCRIPTION
# 概要

このプルリクエストは、HTTP v1 に移行するため、廃止予定の`andpush` gemから新しい`fcm` gemへのFCM統合の更新について説明しています。設定、ペイロードテンプレート、アダプター実装、テストケースの変更が含まれ、新しいgemのAPIと機能に合わせて調整されています。

## FCM設定と依存関係の更新

* **`Gemfile`**: `fcm` gemをバージョン`~> 2.0.0`に更新し、廃止予定の`andpush` gemへの参照を削除しました。
* **`README.md`**: 新しい`fcm` gemの使用方法を反映してFCM設定例を更新し、`server_key`を`google_application_credentials`と`firebase_project_id`に置き換えました。

## FCMアダプター実装の変更

* **`lib/pushing/adapters/fcm/fcm_gem_adapter.rb`**: FCMアダプターを`fcm` gemの`send_v1`メソッドを使用するようにリファクタリングし、`google_application_credentials`と`firebase_project_id`を受け取るように初期化を更新しました。詳細なデバッグ情報を含むエラーハンドリングを改善しました。

## ペイロードテンプレートの更新

* **`lib/generators/pushing/templates/template.json+fcm.jbuilder`**: レガシーなペイロード構造を`fcm` gemと互換性のある新しいテンプレートに置き換え、`android`、`webpush`、`apns`などの高度な設定オプションのサポートを追加しました。

## テストスイートの調整

* **`test/integration/fcm_test_cases.rb`**: 新しいFCM APIエンドポイント（`https://fcm.googleapis.com/v1/projects/.../messages:send`）を使用するようにテストケースを更新し、動的URL生成のためのヘルパーメソッドを追加しました。
* **`test/integration/test_helper.rb`**: FCM統合テスト用に`google_application_credentials`と`firebase_project_id`を使用するようにテスト設定を更新しました。

## 関連資料

* [以前の FCM API から HTTP v1 に移行する](https://firebase.google.com/docs/cloud-messaging/migrate-v1?hl=ja)